### PR TITLE
feat: add `snakeCase` function

### DIFF
--- a/src/functions/index.ts
+++ b/src/functions/index.ts
@@ -49,6 +49,7 @@ export * from './sample';
 export * from './set';
 export * from './shuffle';
 export * from './single';
+export * from './snakeCase';
 export * from './startCase';
 export * from './sum';
 export * from './take';

--- a/src/functions/snakeCase/index.ts
+++ b/src/functions/snakeCase/index.ts
@@ -1,0 +1,1 @@
+export * from './snakeCase';

--- a/src/functions/snakeCase/snakeCase.spec.ts
+++ b/src/functions/snakeCase/snakeCase.spec.ts
@@ -1,0 +1,150 @@
+import { expect, expectTypeOf, it } from 'vitest';
+
+import { snakeCase } from './snakeCase';
+
+it('should convert camelCase to snake_case', () => {
+  const result = snakeCase('fooBarBaz');
+  const expected = 'foo_bar_baz';
+  expect(result).toBe(expected);
+  expectTypeOf(result).toEqualTypeOf<typeof expected>();
+});
+
+it('should convert PascalCase to snake_case', () => {
+  const result = snakeCase('FooBarBaz');
+  const expected = 'foo_bar_baz';
+  expect(result).toBe(expected);
+  expectTypeOf(result).toEqualTypeOf<typeof expected>();
+});
+
+it('should convert kebab-case to snake_case', () => {
+  const result = snakeCase('foo-bar-baz');
+  const expected = 'foo_bar_baz';
+  expect(result).toBe(expected);
+  expectTypeOf(result).toEqualTypeOf<typeof expected>();
+});
+
+it('should convert spaces to underscores', () => {
+  const result = snakeCase('foo bar baz');
+  const expected = 'foo_bar_baz';
+  expect(result).toBe(expected);
+  expectTypeOf(result).toEqualTypeOf<typeof expected>();
+});
+
+it('should convert CONSTANT_CASE to snake_case', () => {
+  const result = snakeCase('FOO_BAR_BAZ');
+  const expected = 'foo_bar_baz';
+  expect(result).toBe(expected);
+  expectTypeOf(result).toEqualTypeOf<typeof expected>();
+});
+
+it('should return an empty string for an empty string', () => {
+  const result = snakeCase('');
+  const expected = '';
+  expect(result).toBe(expected);
+  expectTypeOf(result).toEqualTypeOf<typeof expected>();
+});
+
+it('should convert a single uppercase letter to lowercase', () => {
+  const result = snakeCase('A');
+  const expected = 'a';
+  expect(result).toBe(expected);
+  expectTypeOf(result).toEqualTypeOf<typeof expected>();
+});
+
+it('should convert a single lowercase letter to lowercase', () => {
+  const result = snakeCase('z');
+  const expected = 'z';
+  expect(result).toBe(expected);
+  expectTypeOf(result).toEqualTypeOf<typeof expected>();
+});
+
+it('should return the same for non-alphabetic strings', () => {
+  const result = snakeCase('123');
+  const expected = '123';
+  expect(result).toBe(expected);
+  expectTypeOf(result).toEqualTypeOf<typeof expected>();
+});
+
+it('should convert a string with only uppercase letters to lowercase', () => {
+  const result = snakeCase('FOOBARBAZ');
+  const expected = 'foobarbaz';
+  expect(result).toBe(expected);
+  expectTypeOf(result).toEqualTypeOf<typeof expected>();
+});
+
+it('should convert a string with only lowercase letters to snake_case', () => {
+  const result = snakeCase('foobarbaz');
+  const expected = 'foobarbaz';
+  expect(result).toBe(expected);
+  expectTypeOf(result).toEqualTypeOf<typeof expected>();
+});
+
+it('should handle leading and trailing hyphens', () => {
+  const result = snakeCase('--foo-bar--');
+  const expected = 'foo_bar';
+  expect(result).toBe(expected);
+  expectTypeOf(result).toEqualTypeOf<typeof expected>();
+});
+
+it('should handle leading and trailing underscores', () => {
+  const result = snakeCase('__FOO_BAR__');
+  const expected = 'foo_bar';
+  expect(result).toBe(expected);
+  expectTypeOf(result).toEqualTypeOf<typeof expected>();
+});
+
+it('should convert a string with mixed case and numbers to snake_case', () => {
+  const result = snakeCase('fooBar123Baz');
+  const expected = 'foo_bar123_baz';
+  expect(result).toBe(expected);
+  expectTypeOf(result).toEqualTypeOf<typeof expected>();
+});
+
+it('should convert a string with mixed separators to snake_case', () => {
+  const result = snakeCase('foo-bar_baz');
+  const expected = 'foo_bar_baz';
+  expect(result).toBe(expected);
+  expectTypeOf(result).toEqualTypeOf<typeof expected>();
+});
+
+it('should handle leading and trailing spaces', () => {
+  const result = snakeCase('  foo bar baz  ');
+  const expected = 'foo_bar_baz';
+  expect(result).toBe(expected);
+  expectTypeOf(result).toEqualTypeOf<typeof expected>();
+});
+
+it('should handle multiple consecutive spaces', () => {
+  const result = snakeCase('foo   bar   baz');
+  const expected = 'foo_bar_baz';
+  expect(result).toBe(expected);
+  expectTypeOf(result).toEqualTypeOf<typeof expected>();
+});
+
+it('should handle multiple consecutive underscores', () => {
+  const result = snakeCase('foo___bar___baz');
+  const expected = 'foo_bar_baz';
+  expect(result).toBe(expected);
+  expectTypeOf(result).toEqualTypeOf<typeof expected>();
+});
+
+it('should handle multiple consecutive hyphens', () => {
+  const result = snakeCase('foo---bar---baz');
+  const expected = 'foo_bar_baz';
+  expect(result).toBe(expected);
+  expectTypeOf(result).toEqualTypeOf<typeof expected>();
+});
+
+it('should handle acronyms at the start', () => {
+  const result = snakeCase('FOOBar');
+  const expected = 'foo_bar';
+  expect(result).toBe(expected);
+  expectTypeOf(result).toEqualTypeOf<typeof expected>();
+});
+
+it('should convert snake_case input unchanged', () => {
+  const result = snakeCase('foo_bar');
+  const expected = 'foo_bar';
+  expect(result).toBe(expected);
+  expectTypeOf(result).toEqualTypeOf<typeof expected>();
+});

--- a/src/functions/snakeCase/snakeCase.ts
+++ b/src/functions/snakeCase/snakeCase.ts
@@ -1,0 +1,70 @@
+import type { SnakeCase as SnakeCaseImplementation } from 'type-fest';
+
+/**
+ * Changes the casing of a string to snake case.
+ * @param string The input string to change the casing of.
+ * @returns A new string with the casing changed to snake case.
+ * @example
+ * ```ts
+ * snakeCase('fooBar') // 'foo_bar'
+ * snakeCase('foo bar') // 'foo_bar'
+ * snakeCase('foo-bar') // 'foo_bar'
+ * snakeCase('fooBar42') // 'foo_bar42'
+ * ```
+ */
+export function snakeCase<S extends string>(string: S): SnakeCase<S> {
+  if (!/[a-z]+/i.test(string)) {
+    return string as SnakeCase<S>;
+  }
+
+  return string
+    .replace(/[_-]+/g, ' ')
+    .match(SNAKE_REGEX)
+    ?.map((x) => x.toLowerCase())
+    .join('_') as SnakeCase<S>;
+}
+
+const SNAKE_REGEX = /[A-Z]{2,}(?=[A-Z][a-z]+\d*|\b)|[A-Z]?[a-z]+\d*|[A-Z]|\d+/g;
+
+/**
+ * Changes the casing of a string to snake case.
+ * @see {@link snakeCase}.
+ */
+export type SnakeCase<S extends string> = TrimUnderscores<
+  ReduceUnderscores<SnakeCaseImplementation<S>>
+>;
+
+/**
+ * Reduces multiple underscores to a single underscore.
+ * @param S The input string.
+ * @returns A new string with multiple underscores reduced to a single underscore.
+ * @example
+ * ```ts
+ * ReduceUnderscores<'foo__bar'> // 'foo_bar'
+ * ReduceUnderscores<'foo_bar'> // 'foo_bar'
+ * ReduceUnderscores<'foo___bar'> // 'foo_bar'
+ * ```
+ */
+type ReduceUnderscores<S extends string> = S extends `${infer L}__${infer R}`
+  ? ReduceUnderscores<`${L}_${R}`>
+  : S extends `${infer L}${infer D}__${infer R}`
+    ? ReduceUnderscores<`${L}${D}_${R}`>
+    : S;
+
+/**
+ * Trims underscores from the start and end of a string.
+ * @param S The input string.
+ * @returns A new string with underscores trimmed from the start and end.
+ * @example
+ * ```ts
+ * TrimUnderscores<'_foo_bar_'> // 'foo_bar'
+ * TrimUnderscores<'foo_bar_'> // 'foo_bar'
+ * TrimUnderscores<'_foo_bar'> // 'foo_bar'
+ * TrimUnderscores<'foo_bar'> // 'foo_bar'
+ * ```
+ */
+type TrimUnderscores<S extends string> = S extends `_${infer R}`
+  ? TrimUnderscores<R>
+  : S extends `${infer L}_`
+    ? TrimUnderscores<L>
+    : S;


### PR DESCRIPTION
## Summary
- Adds `snakeCase` utility that converts strings to snake_case
- Handles kebab-case, camelCase, PascalCase, spaces, CONSTANT_CASE, and mixed formats
- Type-level `SnakeCase<S>` using type-fest