### PR TITLE
feat: add `shuffle` function

### DIFF
--- a/src/functions/index.ts
+++ b/src/functions/index.ts
@@ -47,6 +47,7 @@ export * from './pipe';
 export * from './range';
 export * from './sample';
 export * from './set';
+export * from './shuffle';
 export * from './single';
 export * from './startCase';
 export * from './sum';

--- a/src/functions/shuffle/index.ts
+++ b/src/functions/shuffle/index.ts
@@ -1,0 +1,1 @@
+export * from './shuffle';

--- a/src/functions/shuffle/shuffle.spec.ts
+++ b/src/functions/shuffle/shuffle.spec.ts
@@ -1,0 +1,64 @@
+import { expect, expectTypeOf, it } from 'vitest';
+
+import { shuffle } from './shuffle';
+
+it('returns an array with the same length as the input', () => {
+  const result = shuffle([1, 2, 3, 4]);
+  expect(result).toHaveLength(4);
+});
+
+it('returns an array containing all the same elements', () => {
+  const input = [1, 2, 3, 4, 5];
+  const result = shuffle(input);
+  expect(result).toHaveLength(input.length);
+  expect(result).toEqual(expect.arrayContaining(input));
+  expect(input).toEqual(expect.arrayContaining(result));
+});
+
+it('does not mutate the original array', () => {
+  const input = [1, 2, 3, 4];
+  const copy = [...input];
+  shuffle(input);
+  expect(input).toEqual(copy);
+});
+
+it('returns an empty array for an empty input', () => {
+  expect(shuffle([])).toEqual([]);
+});
+
+it('returns an empty array for null', () => {
+  expect(shuffle(null)).toEqual([]);
+});
+
+it('returns an empty array for undefined', () => {
+  expect(shuffle(undefined)).toEqual([]);
+});
+
+it('returns a single-element array unchanged', () => {
+  expect(shuffle([42])).toEqual([42]);
+});
+
+it('returns a new array reference', () => {
+  const input = [1, 2, 3];
+  const result = shuffle(input);
+  expect(result).not.toBe(input);
+});
+
+it('should return T[] type', () => {
+  expectTypeOf(shuffle([1, 2, 3])).toEqualTypeOf<number[]>();
+  expectTypeOf(shuffle(['a', 'b'])).toEqualTypeOf<string[]>();
+});
+
+it('should accept readonly arrays', () => {
+  const input: readonly number[] = [1, 2, 3];
+  const result = shuffle(input);
+  expectTypeOf(result).toEqualTypeOf<number[]>();
+  expect(result).toHaveLength(3);
+});
+
+it('should accept null and undefined inputs', () => {
+  const nullResult = shuffle(null);
+  const undefinedResult = shuffle(undefined);
+  expectTypeOf(nullResult).toBeArray();
+  expectTypeOf(undefinedResult).toBeArray();
+});

--- a/src/functions/shuffle/shuffle.ts
+++ b/src/functions/shuffle/shuffle.ts
@@ -1,0 +1,26 @@
+import type { Maybe } from '../../types';
+
+/**
+ * Returns a new array with elements randomly reordered using the Fisher-Yates algorithm.
+ * Does not mutate the input array.
+ * @param array The array to shuffle.
+ * @returns A new array with the same elements in a random order.
+ * @example
+ * ```ts
+ * shuffle([1, 2, 3, 4]) // e.g. [3, 1, 4, 2]
+ * shuffle([]) // []
+ * shuffle(null) // []
+ * shuffle(undefined) // []
+ * ```
+ */
+export function shuffle<T>(array: Maybe<readonly T[]>): T[] {
+  const result = [...(array ?? [])];
+
+  for (let i = result.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    // biome-ignore lint/style/noNonNullAssertion: indices i and j are guaranteed to be within bounds
+    [result[i], result[j]] = [result[j]!, result[i]!];
+  }
+
+  return result;
+}


### PR DESCRIPTION
## Summary
- Adds `shuffle` utility using Fisher-Yates algorithm
- Returns a new array (no mutation), accepts `Maybe<readonly T[]>`
- Handles null/undefined inputs gracefully
