### PR TITLE
Fix prototype pollution in set function

### DIFF
--- a/src/functions/set/set.spec.ts
+++ b/src/functions/set/set.spec.ts
@@ -83,3 +83,17 @@ it('should not allow passing in a potentially unsafe path', () => {
   ).toThrow('Potentially malicious path');
   expect(object).toEqual({ foo: 'bar' });
 });
+
+it('should create intermediate objects without a prototype chain', () => {
+  const object: {
+    foo?: {
+      bar?: string;
+    };
+  } = {};
+
+  set(object, 'foo.bar', 'baz');
+
+  // Intermediate objects should not have Object.prototype methods
+  // to prevent prototype pollution attacks
+  expect(Object.getPrototypeOf(object.foo)).toBeNull();
+});

--- a/src/functions/set/set.ts
+++ b/src/functions/set/set.ts
@@ -46,7 +46,7 @@ export function set<
     // biome-ignore lint/style/noNonNullAssertion: trust the compiler (and unit tests 😄).
     const segment = segments[index]!;
     if (segment in currentObject === false) {
-      currentObject[segment] = {};
+      currentObject[segment] = Object.create(null) as Record<string, unknown>;
     }
     currentObject = currentObject[segment];
   }


### PR DESCRIPTION
## Summary

- Use `Object.create(null)` instead of `{}` for intermediate objects created during nested path traversal in `set()`
- Resolves CodeQL alerts [#4](https://github.com/bengry/typedash/security/code-scanning/4) and [#5](https://github.com/bengry/typedash/security/code-scanning/5)

Plain `{}` objects inherit from `Object.prototype`, which CodeQL correctly flags as a prototype pollution vector. Null-prototype objects have no inherited properties, eliminating the attack surface.

## Test plan
- [x] Added test verifying intermediate objects have null prototype
- [x] All existing set tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a security vulnerability in the set function that could allow prototype pollution attacks. Intermediate objects created during nested operations now have null prototypes, preventing unauthorized property injection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->