### PR TITLE
Fix release workflow failing due to git hooks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,10 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
+      - name: Disable git hooks
+        run: git config --unset core.hooksPath || true
+
       - name: Release
-        run: pnpm release-it ${{ inputs.release-type }} --ci
+        run: LEFTHOOK=0 pnpm release-it ${{ inputs.release-type }} --ci
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Disable lefthook via `LEFTHOOK=0` env var in the release workflow
- Unset `core.hooksPath` as a fallback

The `czg` prepare-commit-msg hook requires a TTY (`/dev/tty`) which doesn't exist in CI, causing `release-it` to fail and roll back.
