### PR TITLE
Fix release workflow for branch protection rules

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -1,0 +1,31 @@
+name: Tag Release
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  tag-release:
+    if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release/v')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Extract version from branch name
+        id: version
+        run: |
+          version="${{ github.event.pull_request.head.ref }}"
+          version="${version#release/v}"
+          echo "tag=${version}" >> "$GITHUB_OUTPUT"
+
+      - name: Create GitHub Release
+        run: gh release create "${{ steps.version.outputs.tag }}" --generate-notes --latest
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   release:
@@ -23,8 +24,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Enable corepack
         shell: bash
@@ -33,15 +32,40 @@ jobs:
       - name: Install dependencies
         uses: ./.github/actions/pnpm-nm-install
 
-      - name: Configure git
+      - name: Compute next version
+        id: version
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          current=$(jq -r .version package.json)
+          IFS='.' read -r major minor patch <<< "$current"
+          case "${{ inputs.release-type }}" in
+            major) major=$((major + 1)); minor=0; patch=0 ;;
+            minor) minor=$((minor + 1)); patch=0 ;;
+            patch) patch=$((patch + 1)) ;;
+          esac
+          echo "next=${major}.${minor}.${patch}" >> "$GITHUB_OUTPUT"
+          echo "Bumping $current → ${major}.${minor}.${patch}"
 
-      - name: Disable git hooks
-        run: git config --unset core.hooksPath || true
+      - name: Bump version in package.json
+        run: |
+          jq --arg v "${{ steps.version.outputs.next }}" '.version = $v' package.json > package.json.tmp
+          mv package.json.tmp package.json
 
-      - name: Release
-        run: LEFTHOOK=0 pnpm release-it ${{ inputs.release-type }} --ci
+      - name: Create release PR
+        uses: peter-evans/create-pull-request@v7
+        id: create-pr
+        with:
+          commit-message: "chore(release): v${{ steps.version.outputs.next }}"
+          branch: release/v${{ steps.version.outputs.next }}
+          delete-branch: true
+          title: "chore(release): v${{ steps.version.outputs.next }}"
+          body: |
+            Automated ${{ inputs.release-type }} release bump to v${{ steps.version.outputs.next }}.
+
+            After merging, a GitHub Release will be created automatically which triggers publishing to npm and JSR.
+          labels: automated
+
+      - name: Enable auto-merge
+        if: steps.create-pr.outputs.pull-request-number
+        run: gh pr merge ${{ steps.create-pr.outputs.pull-request-number }} --squash --auto
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Summary

Reworks the release workflow to work with repository rulesets that require PRs and status checks.

**Old flow** (broken): `release-it` bumps version and pushes directly to main → blocked by ruleset.

**New flow:**
1. **Trigger**: Actions → Release → pick patch/minor/major
2. **`release.yml`**: computes next version, creates a PR bumping `package.json`, enables auto-merge
3. **PR merges** → **`release-tag.yml`**: detects `release/v*` branch merge, creates a GitHub Release with auto-generated notes
4. **GitHub Release** → **`publish.yml`**: builds, tests, publishes to npm (with provenance) and JSR

## Test plan
- [ ] Trigger Release workflow with "patch" after merging
- [ ] Verify version bump PR is created with auto-merge
- [ ] Verify GitHub Release is created after PR merge
- [ ] Verify publish workflow triggers from the release

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Streamlined release workflow with automated GitHub Release creation from merged commits
  * Added semantic versioning support with automatic version computation and package updates
  * Implemented automated release PR generation with auto-merge capabilities for faster deployments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->