### PR TITLE
Fix release workflow: disable git hooks in CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Install dependencies
         uses: ./.github/actions/pnpm-nm-install
 
+      - name: Disable git hooks
+        run: rm -rf .git/hooks
+
       - name: Compute next version
         id: version
         run: |


### PR DESCRIPTION
## Summary

Adds `rm -rf .git/hooks` after dependency installation in the release workflow. The `prepare` script runs `lefthook install` which sets up hooks requiring a TTY — these crash when `peter-evans/create-pull-request` commits internally.