### PR TITLE
Fix release workflow: use PAT to trigger CI on release PRs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,8 +13,7 @@ on:
           - major
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   release:
@@ -57,6 +56,7 @@ jobs:
         uses: peter-evans/create-pull-request@v7
         id: create-pr
         with:
+          token: ${{ secrets.RELEASE_PAT }}
           commit-message: "chore(release): v${{ steps.version.outputs.next }}"
           branch: release/v${{ steps.version.outputs.next }}
           delete-branch: true
@@ -71,4 +71,4 @@ jobs:
         if: steps.create-pr.outputs.pull-request-number
         run: gh pr merge ${{ steps.create-pr.outputs.pull-request-number }} --squash --auto
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.RELEASE_PAT }}


### PR DESCRIPTION
## Summary

PRs created by `GITHUB_TOKEN` don't trigger other workflows (GitHub prevents recursive loops). This means the release version bump PR never gets CI checks, blocking merge.

Uses a PAT (`RELEASE_PAT` secret) for `peter-evans/create-pull-request` and auto-merge so the PR triggers CI normally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced security configuration in the automated release workflow by implementing more restrictive access permissions and improved token management practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->