### PR TITLE
Fix publish not triggering after release

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -28,4 +28,4 @@ jobs:
       - name: Create GitHub Release
         run: gh release create "${{ steps.version.outputs.tag }}" --generate-notes --latest
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.RELEASE_PAT }}


### PR DESCRIPTION
## Summary

Same `GITHUB_TOKEN` anti-recursion issue as #63 — the GitHub Release created by `release-tag.yml` uses `github.token`, so `publish.yml` (triggered by `release: published`) never fires.

Switch to `RELEASE_PAT` for `gh release create`.
