### PR TITLE
Switch to npm trusted publishing (no token needed)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,8 +46,6 @@ jobs:
 
       - name: Publish to npm with provenance
         run: pnpm publish --access public --no-git-checks --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish to JSR
         run: pnpm dlx jsr publish


### PR DESCRIPTION
## Summary

Remove `NPM_TOKEN` secret dependency. npm trusted publishers authenticates via GitHub Actions OIDC (`id-token: write` already set), eliminating the need for long-lived access tokens.

## Setup required

Before merging, configure trusted publishing on npmjs.com:
1. Go to [npmjs.com/package/typedash](https://www.npmjs.com/package/typedash) → **Settings** → **Publishing access**
2. Under **Trusted Publishers**, add:
   - Repository: `bengry/typedash`
   - Workflow: `publish.yml`
   - Environment: *(leave blank)*

## Test plan
- [x] Configure trusted publisher on npmjs.com
- [ ] Trigger a patch release after merging and verify npm publish succeeds