### PR TITLE
Fix missing README on npmjs.com

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
-    "dist"
+    "dist",
+    "README.md"
   ],
   "scripts": {
     "build": "tsdown",


### PR DESCRIPTION
## Summary

npmjs.com shows no README for typedash (even on older versions like 3.2.5). `pnpm publish` doesn't always populate the readme metadata correctly.

Explicitly adds `README.md` to the `files` field in `package.json` to ensure it's included in the tarball.

## Test plan
- [ ] After next publish, verify README appears on npmjs.com