### PR TITLE
Fix JSR publishing: sync jsr.json version during releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,10 +47,12 @@ jobs:
           echo "next=${major}.${minor}.${patch}" >> "$GITHUB_OUTPUT"
           echo "Bumping $current → ${major}.${minor}.${patch}"
 
-      - name: Bump version in package.json
+      - name: Bump version in package.json and jsr.json
         run: |
           jq --arg v "${{ steps.version.outputs.next }}" '.version = $v' package.json > package.json.tmp
           mv package.json.tmp package.json
+          jq --arg v "${{ steps.version.outputs.next }}" '.version = $v' jsr.json > jsr.json.tmp
+          mv jsr.json.tmp jsr.json
 
       - name: Create release PR
         uses: peter-evans/create-pull-request@v7

--- a/jsr.json
+++ b/jsr.json
@@ -1,5 +1,5 @@
 {
   "name": "@typedash/typedash",
-  "version": "3.2.5",
+  "version": "3.3.3",
   "exports": "./src/index.ts"
 }


### PR DESCRIPTION
## Summary

JSR publish was skipping with "already published" because `jsr.json` had a hardcoded version `3.2.5` that was never updated by the release workflow.

- Update `jsr.json` to current version (`3.3.3`)
- Update release workflow to bump both `package.json` and `jsr.json`

## Test plan
- [ ] Trigger a patch release after merging and verify JSR publish succeeds