### PR TITLE
chore: switch renovate to config:recommended

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:best-practices", ":semanticCommitTypeAll(chore)"],
+  "extends": ["config:recommended", ":semanticCommitTypeAll(chore)"],
   "timezone": "Asia/Jerusalem",
   "schedule": ["before 9am on monday"],
   "postUpdateOptions": ["pnpmDedupe"],


### PR DESCRIPTION
## Summary
- Switches Renovate preset from `config:best-practices` to `config:recommended`
- `best-practices` includes `:pinDevDependencies` which strips semver ranges from devDependencies, creating unnecessary pin PRs (e.g. #72, #73)
- Since we have a lockfile, pinning is redundant

## Test plan
- Verify Renovate picks up the new config and stops opening pin PRs
- PRs #72 and #73 should be auto-closed by Renovate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Renovate dependency automation configuration, switching from the best-practices preset to the recommended preset. This change may affect default behaviors for automated dependency management, including how updates are identified, scheduled, and applied, while preserving existing semantic commit message conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->