### PR TITLE
chore(deps): update dev dependencies and type-fest

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,29 +63,29 @@
     "util:function-count": "exa -1 | grep -v '^_' | wc -l"
   },
   "dependencies": {
-    "type-fest": "^5.4.4"
+    "type-fest": "^5.5.0"
   },
   "optionalDependencies": {
     "react": ">=18 < 20"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.3.15",
-    "@commitlint/cli": "^20.4.1",
-    "@commitlint/config-conventional": "^20.4.1",
-    "czg": "^1.12.0",
-    "@types/node": "^24.10.13",
+    "@biomejs/biome": "^2.4.9",
+    "@commitlint/cli": "^20.5.0",
+    "@commitlint/config-conventional": "^20.5.0",
+    "@types/node": "^24.12.0",
     "@types/react": "^19.2.14",
-    "@vitest/coverage-v8": "^4.0.18",
-    "@vitest/ui": "^4.0.18",
+    "@vitest/coverage-v8": "^4.1.1",
+    "@vitest/ui": "^4.1.1",
     "concurrently": "^9.2.1",
-    "lefthook": "^2.1.1",
+    "czg": "^1.12.0",
+    "lefthook": "^2.1.4",
     "react": "^19.2.4",
     "release-it": "^19.2.4",
-    "taze": "^19.9.2",
-    "tsdown": "^0.21.0",
+    "taze": "^19.10.0",
+    "tsdown": "^0.21.4",
     "type-fest": "^5.4.4",
-    "typescript": "^6.0.0",
-    "vitest": "^4.0.18"
+    "typescript": "^6.0.2",
+    "vitest": "^4.1.1"
   },
   "packageManager": "pnpm@10.33.0",
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,29 +9,29 @@ importers:
   .:
     dependencies:
       type-fest:
-        specifier: ^5.4.4
+        specifier: ^5.5.0
         version: 5.5.0
     devDependencies:
       '@biomejs/biome':
-        specifier: ^2.3.15
+        specifier: ^2.4.9
         version: 2.4.9
       '@commitlint/cli':
-        specifier: ^20.4.1
+        specifier: ^20.5.0
         version: 20.5.0(@types/node@24.12.0)(conventional-commits-parser@6.3.0)(typescript@6.0.2)
       '@commitlint/config-conventional':
-        specifier: ^20.4.1
+        specifier: ^20.5.0
         version: 20.5.0
       '@types/node':
-        specifier: ^24.10.13
+        specifier: ^24.12.0
         version: 24.12.0
       '@types/react':
         specifier: ^19.2.14
         version: 19.2.14
       '@vitest/coverage-v8':
-        specifier: ^4.0.18
+        specifier: ^4.1.1
         version: 4.1.1(vitest@4.1.1)
       '@vitest/ui':
-        specifier: ^4.0.18
+        specifier: ^4.1.1
         version: 4.1.1(vitest@4.1.1)
       concurrently:
         specifier: ^9.2.1
@@ -40,22 +40,22 @@ importers:
         specifier: ^1.12.0
         version: 1.12.0
       lefthook:
-        specifier: ^2.1.1
+        specifier: ^2.1.4
         version: 2.1.4
       release-it:
         specifier: ^19.2.4
         version: 19.2.4(@types/node@24.12.0)(magicast@0.5.2)
       taze:
-        specifier: ^19.9.2
+        specifier: ^19.10.0
         version: 19.10.0
       tsdown:
-        specifier: ^0.21.0
+        specifier: ^0.21.4
         version: 0.21.4(typescript@6.0.2)
       typescript:
-        specifier: ^6.0.0
+        specifier: ^6.0.2
         version: 6.0.2
       vitest:
-        specifier: ^4.0.18
+        specifier: ^4.1.1
         version: 4.1.1(@types/node@24.12.0)(@vitest/ui@4.1.1)(vite@8.0.2(@types/node@24.12.0)(jiti@2.6.1)(yaml@2.8.3))
     optionalDependencies:
       react:


### PR DESCRIPTION
## Summary

- Bump `type-fest` from ^5.4.4 to ^5.5.0 (runtime dep)
- Update dev dependencies: biome, commitlint, @types/node, vitest, coverage-v8, lefthook, taze, tsdown, typescript
- Lock file updated accordingly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development and build tool dependencies to their latest compatible versions, ensuring improved stability and access to recent tool enhancements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->