### PR TITLE
build(tsdown): enable minification and disable chunk hashing

### DIFF
--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -22,11 +22,13 @@ export default defineConfig(async () => {
       ),
     },
     treeshake: true,
+    minify: true,
     sourcemap: true,
     platform: 'neutral',
     clean: true,
     dts: true,
     format: ['cjs', 'esm'],
+    hash: false,
     tsconfig: 'tsconfig.build.json',
   } satisfies UserConfig;
 });


### PR DESCRIPTION
## Summary

Two targeted build config changes to reduce published bundle size:

- **`minify: true`** — enables minification of emitted JS output, stripping whitespace and shortening identifiers
- **`hash: false`** — removes content hashes from chunk filenames, reducing import specifier overhead for consumers

## Measured Impact

Benchmarked against the state before this PR (measurements taken prior to the pick/isEqual source changes in #103, so exact numbers may differ slightly now):

| Artifact | Before (gzip) | After (gzip) | Delta |
|---|---|---|---|
| Root ESM | 1217 B | 948 B | **−22%** |
| Root bundle proxy | 15042 B | 4758 B | **−68%** |
| All built index artifacts | 21838 B | 14270 B | **−35%** |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to optimize output file sizes through minification and streamlined artifact naming for improved distribution efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->