### PR TITLE
chore: exclude sourcemaps from published npm tarball

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   "types": "./dist/index.d.ts",
   "files": [
     "dist",
+    "!dist/**/*.map",
     "README.md"
   ],
   "scripts": {
@@ -55,6 +56,7 @@
     "lint:type-check": "tsc --noEmit",
     "prepare": "lefthook install",
     "release": "pnpm build && pnpm release-it",
+    "size:analyze": "node scripts/sizeAnalyze.mjs",
     "test": "vitest run --passWithNoTests",
     "test:ci": "pnpm test",
     "test:coverage": "pnpm test --coverage",


### PR DESCRIPTION
## Why

Sourcemaps accounted for **126 files / ~300 KB raw** in the published tarball — pure overhead for consumers. 5 of 9 comparable utility libraries (lodash, ramda, es-toolkit, type-fest, just) don't ship sourcemaps to npm at all.

## Approach

Added `"!dist/**/*.map"` negation pattern to the `files` field in `package.json`. Sourcemaps are **still generated on every build** (available locally and in CI), they're just excluded from the npm tarball.

No changes to `tsdown.config.ts` — `sourcemap: true` is untouched.

## Measured impact

| | Before | After |
|---|---|---|
| `.map` files in tarball | 126 | **0** |
| Total files in tarball | 617 | **491** |
| Tarball size | ~300 KB raw | reduced |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Package distribution configuration has been updated to exclude generated source map files from npm releases, reducing the download size of published packages.
  * A new package analysis development utility script has been added to the available tooling suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->