### PR TITLE
fix: remove accidentally shipped size:analyze script

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "lint:type-check": "tsc --noEmit",
     "prepare": "lefthook install",
     "release": "pnpm build && pnpm release-it",
-    "size:analyze": "node scripts/sizeAnalyze.mjs",
     "test": "vitest run --passWithNoTests",
     "test:ci": "pnpm test",
     "test:coverage": "pnpm test --coverage",


### PR DESCRIPTION
## Summary

- Removes the `size:analyze` script from `package.json` that was accidentally included in #105
- The script references `scripts/sizeAnalyze.mjs` which is not committed to the repo — it's a local dev-only tool