### PR TITLE
perf: inline small dependencies to reduce per-function bundle size

### DIFF
--- a/src/functions/assert/assert.ts
+++ b/src/functions/assert/assert.ts
@@ -1,5 +1,3 @@
-import { compact } from '../compact';
-
 /**
  * Asserts that a condition is true, throwing an Error if it is not.
  * @param condition A condition that should be true
@@ -43,11 +41,6 @@ export function assert(
  */
 export class AssertionError extends Error {
   constructor(message?: string) {
-    super(
-      compact([
-        'Assertion not satisfied',
-        message ? `: "${message}"` : '',
-      ]).join('')
-    );
+    super(`Assertion not satisfied${message ? `: "${message}"` : ''}`);
   }
 }

--- a/src/functions/orderBy/orderBy.ts
+++ b/src/functions/orderBy/orderBy.ts
@@ -1,7 +1,6 @@
 import type { Primitive } from 'type-fest';
 
 import type { KeysOfUnion, Many, Maybe } from '../../types';
-import { castArray } from '../castArray';
 
 /**
  * Sorts an array of objects by one or more properties, in ascending or descending order.
@@ -17,13 +16,20 @@ export function orderBy<TValue>(
 ): TValue[] {
   if (array == null) return [];
 
-  const normalizedIteratees = castArray(iterators).map((iteratee) =>
+  const normalizedIteratees = (
+    Array.isArray(iterators) ? iterators : [iterators]
+  ).map<(value: TValue) => ComparableValue>((iteratee) =>
     typeof iteratee === 'function'
       ? iteratee
-      : (value: TValue) => value[iteratee]
+      : (value) =>
+          (value as Record<string, ComparableValue>)[iteratee as string]
   );
 
-  const normalizedOrders = castArray(orders);
+  const normalizedOrders = Array.isArray(orders)
+    ? orders
+    : orders != null
+      ? [orders]
+      : [];
 
   return [...array].sort((a, b) => {
     for (const [index, iteratee] of normalizedIteratees.entries()) {

--- a/src/functions/set/set.ts
+++ b/src/functions/set/set.ts
@@ -2,8 +2,11 @@ import type { Get } from 'type-fest';
 
 import type { ObjectPath } from '../../types';
 import type { RequireKeysDeep } from '../../types/_internal';
-import { isMaliciousObjectProperty } from '../_internal/isMaliciousObjectPath';
 import { assert } from '../assert';
+
+const MALICIOUS_PROPS = new Set(
+  Object.getOwnPropertyNames(Object.getPrototypeOf({}))
+);
 
 /**
  * Sets a value at the specified (possibly nested) path in an object.
@@ -36,7 +39,7 @@ export function set<
   const segments = path.match(pathSegmentsRegex);
   assert(segments !== null, 'Invalid path');
   assert(
-    segments.every((segment) => isMaliciousObjectProperty(segment) === false),
+    segments.every((segment) => !MALICIOUS_PROPS.has(segment)),
     'Potentially malicious path'
   );
 


### PR DESCRIPTION
## Summary

Inline small helper dependencies at call sites to eliminate unnecessary import chains, reducing per-function bundle sizes.

### Changes

- **`assert`**: Replace `compact` import with template literal for error message construction. Eliminates `compact` from `assert`'s dependency graph.
  - assert gzip: 242 → 209 B (−14%)
- **`set`**: Inline `isMaliciousObjectPath` with a local `Set`, removing the `createTypeGuard` dependency entirely.
  - set proxy gzip: 333 → 317 B (−5%)  
- **`orderBy`**: Inline `castArray` calls with `Array.isArray` checks, removing the `castArray` → `castArrayIfDefined` → `isArray` chain.
  - orderBy proxy gzip: 272 → 269 B (−1%)

### Aggregate

- All function entry points total gzip: 5,208 → 5,049 B (−3%)
- 501/501 tests pass, typecheck clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal error message construction in assertion handling.
  * Improved array normalization logic in ordering functions.
  * Enhanced security property validation with precomputed lookup for improved performance.

**Note:** These are internal implementation improvements with no changes to user-facing functionality or API behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->