### PR TITLE
feat!: drop CJS format, ship ESM-only

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,16 +22,14 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "require": "./dist/index.cjs",
-      "import": "./dist/index.js"
+      "default": "./dist/index.js"
     },
     "./*": {
       "types": "./dist/*/index.d.ts",
-      "require": "./dist/*/index.cjs",
-      "import": "./dist/*/index.js"
+      "default": "./dist/*/index.js"
     }
   },
-  "main": "./dist/index.cjs",
+  "main": "./dist/index.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -27,7 +27,7 @@ export default defineConfig(async () => {
     platform: 'neutral',
     clean: true,
     dts: true,
-    format: ['cjs', 'esm'],
+    format: ['esm'],
     hash: false,
     tsconfig: 'tsconfig.build.json',
   } satisfies UserConfig;


### PR DESCRIPTION
## Summary

**BREAKING CHANGE**: Drop CommonJS output — typedash now ships ESM only.

### Changes
- `tsdown.config.ts`: `format: ['cjs', 'esm']` → `format: ['esm']`
- `package.json`: Remove `require` conditions from exports, update `main` to `.js`

### Impact
- Zero `.cjs` and `.d.cts` files in dist/
- CJS consumers must migrate to ESM imports or use a bundler
- Follows the trend of es-toolkit, which also ships ESM-primary

### Rationale
- CJS wrapper adds `Object.defineProperty(exports, ...)` overhead (1-40% per file)
- Eliminates ~114 .cjs files and ~130 .d.cts files from the published package
- Modern Node.js (18+) and all bundlers (webpack, esbuild, vite, rollup) fully support ESM