### PR TITLE
ci(sync): auto-close sync issue when main merges cleanly into v4

### DIFF
--- a/.github/workflows/sync-main-into-v4.yml
+++ b/.github/workflows/sync-main-into-v4.yml
@@ -60,6 +60,35 @@ jobs:
               --label "automated"
           fi
 
+      - name: Close sync issue when resolved
+        if: steps.merge.outputs.conflict != 'true'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        with:
+          script: |
+            const title = 'Manual sync needed: main → v4 merge conflict';
+            const { data: issues } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'sync',
+            });
+            const existing = issues.find(i => i.title === title);
+            if (existing) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existing.number,
+                body: `Resolved: \`main\` merges cleanly into \`v4\` as of ${context.sha}. Closing.`,
+              });
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existing.number,
+                state: 'closed',
+                state_reason: 'completed',
+              });
+            }
+
       - name: Open issue on conflict
         if: steps.merge.outputs.conflict == 'true'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9


### PR DESCRIPTION
The sync workflow opened/commented on the conflict issue but never closed it once `main` merged cleanly again. Adds a step that comments + closes the open `sync` issue on a clean (or no-op) merge.

Mirrors the same change already on `v4`. Resolves the lifecycle gap behind #149.