### PR TITLE
fix: add size < 1 guard to chunk

### DIFF
--- a/src/functions/chunk/chunk.spec.ts
+++ b/src/functions/chunk/chunk.spec.ts
@@ -29,3 +29,15 @@ it('should return a single chunk when the array length is less than the chunk si
   const result = chunk(array, 3);
   expect(result).toEqual([[1, 2]]);
 });
+
+it('should return an empty array when the chunk size is zero', () => {
+  const array = [1, 2, 3];
+  const result = chunk(array, 0);
+  expect(result).toEqual([]);
+});
+
+it('should return an empty array when the chunk size is negative', () => {
+  const array = [1, 2, 3];
+  const result = chunk(array, -1);
+  expect(result).toEqual([]);
+});

--- a/src/functions/chunk/chunk.ts
+++ b/src/functions/chunk/chunk.ts
@@ -15,6 +15,10 @@ export function chunk<T>(array: Maybe<readonly T[]>, size: number): T[][] {
     return [];
   }
 
+  if (size < 1){
+    return [];
+  }
+
   const chunks = [];
   for (let index = 0; index < array.length; index += size) {
     chunks.push(array.slice(index, index + size));


### PR DESCRIPTION
Solves https://github.com/bengry/typedash/issues/172

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation for invalid chunk sizes (zero or negative), which now return an empty array instead of proceeding with chunking operations.

* **Tests**
  * Added test cases to verify correct handling of zero and negative chunk size inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->